### PR TITLE
Ft account activation #187419176

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /package-lock.json
 /coverage
 /uploads
+/.vscode

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "author": "atlp",
   "license": "MIT",
   "devDependencies": {
+    "@babel/helper-compilation-targets": "^7.23.6",
     "@eslint/js": "^9.1.1",
     "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.17",

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -188,8 +188,8 @@ export const handleSuccess = async (req: Request, res: Response) => {
         name: user.displayName,
         email: user.emails[0].value,
         username: user.name.familyName,
-        // @ts-ignore
-        password: null,
+        //@ts-ignore
+        password: null
       });
       token = await generateToken(newUser);
       foundUser = newUser;
@@ -204,8 +204,8 @@ export const handleSuccess = async (req: Request, res: Response) => {
   } catch (error: any) {
     return res.status(500).json({
       message: error.message,
-    });
-  }
+});
+}
 };
 
 
@@ -334,3 +334,9 @@ export const otpVerification = async (req: Request, res: Response) => {
       }
   }
 };
+
+export const changeUserAccountStatus = async (req: Request, res: Response) => {
+  const userId = req.params.userId;
+  const updateStatusResult = await userService.updateUserAccountStatus(userId);
+  return res.status(updateStatusResult.status).json(updateStatusResult);
+}

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -13,7 +13,8 @@ import {
    profileSchema,
    updateProfile,
    verifyOTPToken,
-   updateUserRole
+   updateUserRole,
+   changeUserAccountStatus
   } from "./users";
   import {
     RoleSchema,
@@ -117,7 +118,10 @@ const options = {
     get:getSingleCategory,
     patch:updateCategories,
     delete:deleteCategories,
-  } 
+  }, 
+    "/api/v1/users/{userId}/status": {
+      patch: changeUserAccountStatus,
+    }
   },
 
   components: {

--- a/src/docs/users.ts
+++ b/src/docs/users.ts
@@ -330,3 +330,30 @@ export const updateUserRole ={
   },
 };
 
+export const changeUserAccountStatus = {
+  tags: ["Users"],
+  security: [{ bearerAuth: [] }],
+  summary: "change user account status",
+  parameters: [
+    {
+      in: "path",
+      name: "userId",
+      required: true,
+      schema: {
+        type: "string",
+      },
+      description: "ID of the user to change",
+    },
+  ],
+  responses: {
+    200: {
+      description: "OK - User account changed successfully",
+    },
+    404: {
+      description: "Not Found - User not found",
+    },
+    500: {
+      description: "Internal Server Error",
+    }
+  }
+};

--- a/src/email-templates/activation.ts
+++ b/src/email-templates/activation.ts
@@ -1,0 +1,27 @@
+export const activationTemplate = (msg:any, action:any) => {
+    return `<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Account status</title>
+  </head>
+  <body style="font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f8f9fa; display: flex; justify-content: center; align-items: center; height: 100vh; margin: 0;">
+    <div style="width: 80%; max-width: 400px; margin:auto; padding: 30px; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); text-align: center;">
+      <h1 style="color: #333333; font-size: 24px; margin-bottom: 20px;">Account status is ${action}</h1>
+  
+    <p style="color: #666666; font-size: 16px; line-height: 1.6; margin-bottom: 20px;">${
+        action === 'disabled'? "Your account is disabled due to rules violation":
+        "your account is reactivated following recent deactivation now you can use our system"
+    }</p>
+  
+    <p></>
+      <div style="display: flex; justify-content: center;width:100%">
+        <p style="padding: 12px 24px; font-size: 16px; font-weight: bold; color: white; background-color: blue; border: none; border-radius: 5px; cursor: pointer; transition: background-color 0.3s ease;margin:auto;">${msg}</p>
+      </div>
+      </div>
+    </div>
+  </body>
+  </html>`;
+  };
+  

--- a/src/middlewares/isDisabled.ts
+++ b/src/middlewares/isDisabled.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+import User from '../sequelize/models/users';
+
+export const isDisabled = async (req: Request, res: Response, next: NextFunction) => {
+    // @ts-ignore
+    const { email} = req.body;
+    const user = await User.findOne({
+        where:{
+            email:email
+        }
+    });
+    if (user?.isActive === false) {
+      return res.status(403).json({ message: 'Account disabled' });
+    }
+    next();
+  };

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { fetchAllUsers, createUserController, userLogin, updatePassword, tokenVerification, handleSuccess, handleFailure,updateProfileController, getProfileController, otpVerification } from "../controllers/userControllers";
+import { fetchAllUsers, createUserController, userLogin, updatePassword, tokenVerification, handleSuccess, handleFailure,updateProfileController, getProfileController, otpVerification, changeUserAccountStatus } from "../controllers/userControllers";
 import { emailValidation, validateSchema } from "../middlewares/validator";
 import { isLoggedIn } from "../middlewares/isLoggedIn";
 import { passwordUpdateSchema } from "../schemas/passwordUpdate";
@@ -15,6 +15,7 @@ import { roleUpdateSchema } from "../schemas/userRoleUpdateSchema";
 import { updateUserRole } from "../controllers/userControllers";
 import { roleExist } from "../middlewares/roleExist";
 import { userExist } from "../middlewares/userExist";
+import { isDisabled } from "../middlewares/isDisabled";
  
 
 
@@ -22,7 +23,7 @@ const userRoutes = Router();
 
 userRoutes.get("/", fetchAllUsers);
 userRoutes.put("/passwordupdate", isLoggedIn, validateSchema(passwordUpdateSchema), updatePassword)
-userRoutes.post("/login", emailValidation,validateSchema(logInSchema),userLogin);
+userRoutes.post("/login", emailValidation,validateSchema(logInSchema),isDisabled,userLogin);
 userRoutes.post("/register", emailValidation, validateSchema(signUpSchema), createUserController);
 userRoutes.put("/passwordupdate", isLoggedIn, validateSchema(passwordUpdateSchema), updatePassword);
 userRoutes.get("/2fa-verify/:token",tokenVerification);
@@ -40,12 +41,11 @@ userRoutes.patch('/profile',
 )
 
 userRoutes.patch("/:id/role",isLoggedIn, isAdmin, validateSchema(roleUpdateSchema), userExist, roleExist, updateUserRole)
-
+userRoutes.patch('/:userId/status',isLoggedIn, isAdmin, changeUserAccountStatus);
 
 userRoutes.get("/auth/google", authenticateUser);
 userRoutes.get("/auth/google/callback", callbackFn);
 userRoutes.get("/auth/google/success", handleSuccess);
 userRoutes.get("/auth/google/failure", handleFailure);
-
 
 export default userRoutes;

--- a/src/sequelize/migrations/d20240504121420-add-is-active.js
+++ b/src/sequelize/migrations/d20240504121420-add-is-active.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn(
+      'users','isActive',
+      {type: Sequelize.BOOLEAN, 
+      allowNull: false,
+      defaultValue: true})
+  },
+
+  async down (queryInterface, Sequelize) {
+   
+     await queryInterface.removeColumn('users','isActive');
+     
+  }
+};

--- a/src/sequelize/models/users.ts
+++ b/src/sequelize/models/users.ts
@@ -10,6 +10,7 @@ export interface UserAttributes {
   email: string;
   password: string | undefined;
   roleId: number | undefined;
+  isActive?:boolean;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -20,6 +21,7 @@ class User extends Model<UserAttributes> implements UserAttributes {
   username!: string;
   email!: string;
   password!: string;
+  isActive: boolean | undefined;
   roleId!: number | undefined;
   createdAt!: Date | undefined;
   updatedAt!: Date | undefined;
@@ -57,6 +59,11 @@ User.init(
         model: 'Roles',
         key: 'id'
       }
+    },
+    isActive:{
+      type: DataTypes.BOOLEAN,
+      allowNull:false,
+      defaultValue:true
     },
     createdAt: {
       allowNull: false,

--- a/src/services/mail.service.ts
+++ b/src/services/mail.service.ts
@@ -2,7 +2,7 @@ import { IUser } from "../types";
 import { env } from "../utils/env";
 import transporter from "../utils/transporter";
 
-export const sendEmailService = async (user: IUser, subject: string, template: any) => {
+export const sendEmailService = async (user: IUser, subject: string, template: any, token?: number) => {
   try {
     const mailOptions = {
       from: env.smtp_user,


### PR DESCRIPTION
# what does this PR do?
- Enables an admin to activate and deactivate user account 
# description of task to be complete
- Due to varying reasons e.g fraud, abuse, malicious use or violation of terms of service, admin should be able to diable any user account.

- An admin should be able to activate / reactive an account.
for deactivation, send an email to the user with reasons for deactivation

## How should this be manually tested?
1. checkout this branch and run app
2. create a user
3.  patch /api/v1/users/{userId}/status

![Screenshot 2024-05-06 180118](https://github.com/atlp-rwanda/eagles-ec-be/assets/59690243/199d53a9-fe94-4d16-94f6-4e14c4c7c3b6)
![Screenshot 2024-05-06 180218](https://github.com/atlp-rwanda/eagles-ec-be/assets/59690243/2a9ba48e-8bf4-4e86-8bae-2211e36e84ee)


# pivotal tracker id ---->#187419176