### PR TITLE
feat(search): Implement the search products

### DIFF
--- a/__test__/product.test.ts
+++ b/__test__/product.test.ts
@@ -1,6 +1,6 @@
 import request from "supertest";
 import path from "path";
-import fs from 'fs';
+import fs from "fs";
 import { beforeAll, afterAll, jest, test } from "@jest/globals";
 import app from "../src/utils/server";
 import Product from "../src/sequelize/models/products";
@@ -41,6 +41,12 @@ const product:any = {
     password: "soleil00",    
   }
 
+const searchProduct: any = {
+  name: "iphone",
+  minPrice: 0,
+  maxPrice: 0,
+  category: "Electronic device",
+};
 
 describe("Testing product Routes", () => {
     beforeAll(async () => {
@@ -298,7 +304,23 @@ test('It should return status 200 for removed category',async() =>{
   .delete(`/api/v1/categories/${id}`)
   .set("Authorization", "Bearer " + token);
   expect(response.status).toBe(200);
-},20000);
-
+ }, 20000);
+ 
+  test("it should return status 200 when searching product", async () => {
+    const response = await request(app)
+      .get("/api/v1/products/search")
+      .set("Authorization", "Bearer " + token);
+    expect(response.status).toBe(200);
+  });
+  test("return status 200 when none seller role search products", async () => {
+    const response = await request(app).get("/api/v1/products/search").send(searchProduct);
+    expect(response.status).toBe(200);
+  });
+  test("it should return status product is not available when searching product", async () => {
+    const response = await request(app)
+      .get("/api/v1/products/search")
+      .send(searchProduct)
+      .set("Authorization", "Bearer " + token);
+    expect(response.body.status).toBe(404);
+  });
 });
-

--- a/src/controllers/productControllers.ts
+++ b/src/controllers/productControllers.ts
@@ -5,7 +5,8 @@ import {
     createProducts,
     getSingleProduct,
     updateProducts,
-    deleteProduct
+    deleteProduct,
+    searchProduct
 } from "../services/product.service";
 import { ProductType } from "../types";
 
@@ -161,3 +162,18 @@ export const removeProducts = async(req:Request,res:Response) =>{
           }); 
     }
 }
+
+
+export const searchProductController = async (req: Request, res: Response) => {
+    const { name, minPrice, maxPrice, category, expirationDate } = req.query;
+    
+    try {
+        const search = { name, minPrice, maxPrice, category, expirationDate }; 
+        // @ts-ignore
+        const products = await searchProduct(search, req, res); 
+        res.json(products);
+  
+    } catch (error) {
+        res.status(500).json({ error: 'Internal server Error' });
+    }
+};

--- a/src/docs/products.ts
+++ b/src/docs/products.ts
@@ -183,3 +183,61 @@ export const getProducts = {
       },
     }
   }
+
+  export const searchProduct = {
+    tags: ['Products'],
+    security: [{bearerAuth: []}],
+    summary: 'Search products',
+    parameters: [
+      {
+        name: 'name',
+        in: 'query',
+        description: 'Search for products by name',
+       
+        schema: {
+          type: 'string',
+        },
+      },
+      {
+        name: 'minPrice',
+        in: 'query',
+        description: 'Minimum price of product',
+        schema: {
+          type: 'number',
+        },
+      },
+      {
+        name: 'maxPrice',
+        in: 'query',
+        description: 'Maximum price of product',
+        schema: {
+          type: 'number',
+        },
+      },
+      {
+        name: 'category',
+        in: 'query',
+        description: 'Search for products by category',
+        schema: {
+          type: 'string',
+        },
+      },
+      {
+        name: 'expirationDate',
+        in: 'query',
+        description: 'Search expired products',
+        schema: {
+          type: 'date'
+        }
+      }
+    ],
+    responses: {
+      '200': {
+        description: 'Successful response',
+        },
+      },
+      '404': {
+        description: 'No products found',
+      },
+    }
+  

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -29,7 +29,8 @@ import {
     updateProducts,
    getSingleProducts,
    deleteProducts,
-   productSchema } from "./products"; 
+   productSchema, 
+   searchProduct} from "./products"; 
  import {
     getCategories,
     addCategories,
@@ -131,8 +132,11 @@ const options = {
   "/api/v1/wishes/{id}": {
     get: getWishesByProduct,
     delete: deleteWish
-  }
   },
+    "/api/v1/products/search" : {
+      get: searchProduct
+   }
+ },
 
   components: {
     schemas: {

--- a/src/routes/productsRoute.ts
+++ b/src/routes/productsRoute.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import { upload } from "../utils/uploadImages";
-import {  fetchProducts, addProducts, fetchSingleProduct, productsUpdate, removeProducts} from "../controllers/productControllers";
+import {  fetchProducts, addProducts, fetchSingleProduct, productsUpdate, removeProducts, searchProductController} from "../controllers/productControllers";
 import { validateSchema } from "../middlewares/validator";
 import { productDataSchema } from "../schemas/productSchema";
 import { isAseller } from "../middlewares/sellerAuth";
@@ -8,6 +8,8 @@ import { isLoggedIn } from "../middlewares/isLoggedIn";
 import { isCategoryExist } from "../middlewares/isCategoryExist";
 
 const productsRouter = Router();
+productsRouter.get("/search", searchProductController)
+
 productsRouter.get("/",isLoggedIn,isAseller,fetchProducts);
 productsRouter.get("/:id",isLoggedIn,isAseller,fetchSingleProduct);
 productsRouter.post("/",isLoggedIn,isAseller,upload.array('images'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,3 +45,11 @@ export interface CategoryType{
   createdAt:Date,
   updatedAt:Date
   }
+
+  export interface SearchQuery {
+    name?: string;
+    minPrice?: number;
+    maxPrice?: number;
+    category?: string;
+    expirationDate?: Date;
+  }

--- a/src/utils/isSellerOrNormalUser.ts
+++ b/src/utils/isSellerOrNormalUser.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from "express";
+import { decodeToken } from "./jsonwebtoken";
+import { getUserByEmail } from "../services/user.service";
+
+export const authStatus = async (req: Request, res: Response) => {
+  let token: any;
+  try {
+    if (req.headers.authorization && req.headers.authorization.startsWith("Bearer ")) {
+      token = req.headers.authorization.split(" ")[1];
+    }
+    if (!token) {
+      return;
+    }
+    const decoded: any = await decodeToken(token);
+    const loggedUser: any = await getUserByEmail(decoded.email);
+    req.user = loggedUser;
+  } catch (error: any) {
+    throw new Error(error.message);
+  }
+};


### PR DESCRIPTION
**What does this PR do ?**

This PR focus on searching products where users can search different products depend on their preference and can retrieve precisely products based on their  searches.

**Description of the PR**

- A user with the role seller should only allowed to view the own product when he or she searches.
- A user with the role that are not seller can view the all products depends on their searches.

**How should this be manually tested?**

1. Clone the repository.
2. Checkout to the branch ft-search-product-#187419190.
3. Run npm install to install dependencies.
4. Run npm run dev to start the development server.
5. Open a web browser and navigate to the /docs endpoint (e.g., http://localhost:PORT/docs).
6. Verify that the Swagger UI loads correctly.
7. Scroll down to the bottom and click on the search endpoints in Products section and you can search you want.

**What are the relevant pivotal tracker stories?**

[Delivers #187419190]