### PR TITLE
#187419184 fix: sellers should be able to view wishes on their products

### DIFF
--- a/src/controllers/wishesController.ts
+++ b/src/controllers/wishesController.ts
@@ -39,12 +39,12 @@ export const addToWishes = async (req: Request, res: Response) => {
 };
 
 export const getUserWishes = async (req: Request, res: Response) => {
-  const { user } = req;
+  //@ts-ignore
+  const { id, roleId } = req.user;
   try {
-    //@ts-ignore
-    const wishes = await wishlistService.getAllUserWishes(user.id);
-    if (wishes.length == 0) {
-      return res.status(200).json({
+    const wishes = await wishlistService.getAllUserWishes(id, roleId);
+    if (wishes.length === 0) {
+      return res.status(404).json({
         message: "No wishes found",
       });
     } else {
@@ -64,10 +64,10 @@ export const getProductWishes = async (req: Request, res: Response) => {
   const productId = req.params.id;
   try {
     //@ts-ignore
-    const isOwner = await wishlistService.checkOwnership(Number(productId), req.user.id);
-    if (!isOwner) {
-      return res.status(403).json({
-        message: "you're not allowed to access this",
+    const product = await wishlistService.checkOwnership(Number(productId), req.user.id);
+    if (!product) {
+      return res.status(404).json({
+        message: "Product Not Found",
       });
     }
     const wishes = await wishlistService.getProductWishes(Number(productId));
@@ -96,7 +96,7 @@ export const deleteWish = async (req: Request, res: Response) => {
     const isOwner = await wishlistService.getSingleWish(id, productId);
     if (!isOwner) {
       return res.status(404).json({
-        message: "wish product does not exist",
+        message: "product does not exist in your wishes",
       });
     } else {
       await wishlistService.removeProduct(id, productId);

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -122,50 +122,53 @@ const options = {
     "/api/v1/users/{userId}/status": {
       patch: changeUserAccountStatus,
     },
-    "/api/v1/wishes": {
-      post: AddToWishes,
-      get: getWishes,
-    },
-    "/api/v1/products/{id}/status": {
-      patch: changeProductAvailability,
-    },
-    "/api/v1/wishes/{id}": {
-      get: getWishesByProduct,
-      delete: deleteWish,
-    },
-    "/api/v1/products/search": {
-      get: searchProduct,
-    },
-    "/api/v1/carts": {
-      get: viewCartDoc,
-      post: addItemToCartDoc,
-      delete: clearAllProductFromCartDoc,
-      put: removeProductFromCartDoc,
-      patch: updateProductQuantityDoc,
+  "/api/v1/wishes": {
+    post: AddToWishes,
+    get: getWishes
+  } ,
+  "/api/v1/products/{id}/status": {
+    patch: changeProductAvailability,
+  },
+  "/api/v1/messages":{
+    get:joinChats
+  },
+  "/api/v1/products/{id}/wishes": {
+    get: getWishesByProduct,
+    delete: deleteWish
+  },
+    "/api/v1/products/search" : {
+      get: searchProduct
+   },
+   "/api/v1/carts": {
+    get: viewCartDoc,
+    post: addItemToCartDoc,
+    delete: clearAllProductFromCartDoc,
+    put: removeProductFromCartDoc,
+    patch: updateProductQuantityDoc,
+  },
+ },
+ components: {
+  schemas: {
+    Role: RoleSchema,
+    User: userSchema,
+    Login: loginSchema,
+    updatePassword: updatePasswordSchema,
+    Profile: profileSchema,
+    Product:productSchema,
+    Category:categorySchema,
+    Wish: wishSchema
+  },
+  securitySchemes: {
+    bearerAuth: {
+      type: "http",
+      scheme: "bearer",
+      bearerFormat: "JWT",
+      in: "header",
+      name: "Authorization",
     },
   },
-  components: {
-    schemas: {
-      Role: RoleSchema,
-      User: userSchema,
-      Login: loginSchema,
-      updatePassword: updatePasswordSchema,
-      Profile: profileSchema,
-      Product: productSchema,
-      Category: categorySchema,
-      Wish: wishSchema,
-    },
-    securitySchemes: {
-      bearerAuth: {
-        type: "http",
-        scheme: "bearer",
-        bearerFormat: "JWT",
-        in: "header",
-        name: "Authorization",
-      },
-    },
-  },
-};
+}
+}
 docRouter.use("/", serve, setup(options));
 
 export default docRouter;

--- a/src/middlewares/isLoggedIn.ts
+++ b/src/middlewares/isLoggedIn.ts
@@ -18,23 +18,13 @@ export const isLoggedIn = async (req: Request, res: Response, next: NextFunction
                 message: "You are not logged in. Please login to continue.",
             });
         }
-        if (typeof token !== "string") {
-            throw new Error("Token is not a string.");
-        }
-
         const result = await redisClient.lrange('token', 0, 99999999)
-        if (result.indexOf(token) > -1) {
-            return res.status(401).json({
-                message: "You've been logged out, Login again"
-            })
-        }
-
         const decoded: any = await decodeToken(token)
         const loggedUser: any = await getUserByEmail(decoded.email);
-        if (!loggedUser) {
+        if (!loggedUser || (result.indexOf(token) > -1)) {
             return res.status(401).json({
                 status: "Unauthorized",
-                message: "Token has expired. Please login again.",
+                message: "Please login to continue",
             });
         }
         // @ts-ignore

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,9 +8,9 @@ import cartRoutes from "./cartRoutes";
 const appROutes = Router();
 
 appROutes.use("/users", userRoutes);
-appROutes.use("/products", productsRouter);
-appROutes.use("/categories", categoriesRouter);
-appROutes.use("/wishes", wishesRouter);
-appROutes.use("/messages", joinChatRoomRoutes);
+appROutes.use("/products",productsRouter);
+appROutes.use('/categories',categoriesRouter);
+appROutes.use("/messages",joinChatRoomRoutes)
+appROutes.use("/", wishesRouter);
 appROutes.use("/carts", cartRoutes);
 export default appROutes;

--- a/src/routes/wishesRoutes.ts
+++ b/src/routes/wishesRoutes.ts
@@ -6,9 +6,9 @@ import { isAbuyer } from '../middlewares/isAbuyer'
 
 const wishesRouter = express.Router()
 
-wishesRouter.post('/', isLoggedIn, isAbuyer, wishesController.addToWishes)
-wishesRouter.get('/', isLoggedIn, isAbuyer, wishesController.getUserWishes)
-wishesRouter.delete('/:id', isLoggedIn, isAbuyer, wishesController.deleteWish)
-wishesRouter.get('/:id', isLoggedIn, isAseller, wishesController.getProductWishes)
+wishesRouter.post('/wishes', isLoggedIn, isAbuyer, wishesController.addToWishes)
+wishesRouter.get('/wishes', isLoggedIn, wishesController.getUserWishes)
+wishesRouter.delete('/products/:id/wishes', isLoggedIn, isAbuyer, wishesController.deleteWish)
+wishesRouter.get('/products/:id/wishes', isLoggedIn, isAseller, wishesController.getProductWishes)
 
 export default wishesRouter

--- a/src/schemas/wishShema.ts
+++ b/src/schemas/wishShema.ts
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 
 export const wishSchema = Joi.object({
-    productId: Joi.number().required()
+    productId: Joi.number().required(),
+    sellerId: Joi.number().optional()
 })

--- a/src/sequelize/migrations/e20240504074704-create-wishes.js
+++ b/src/sequelize/migrations/e20240504074704-create-wishes.js
@@ -23,6 +23,13 @@ module.exports = {
           key: 'id'
         }
       },
+      sellerId: {
+        type: Sequelize.INTEGER,
+        references:{
+          model: 'users',
+          key: 'id'
+        }
+      },
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE

--- a/src/sequelize/models/wishes.ts
+++ b/src/sequelize/models/wishes.ts
@@ -6,6 +6,7 @@ export interface wishAttributes {
   id?: number;
   userId: number;
   productId: number;
+  sellerId: number;
   createdAt?: Date;
   updatedAt?: Date;
 }
@@ -15,6 +16,7 @@ export interface wishAttributes {
     id!: number | undefined;
     userId!: number;
     productId!: number;
+    sellerId!: number;
     createdAt!: Date | undefined;
     updatedAt!: Date | undefined;
   }
@@ -32,7 +34,15 @@ export interface wishAttributes {
     },
     productId: {
       type: DataTypes.INTEGER,
-      allowNull: false
+      allowNull: false,
+      references:{
+        model:"products",
+        key:"id"
+    }
+    },
+    sellerId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
     },
     createdAt: {
       allowNull: false,

--- a/src/services/wishlist.service.ts
+++ b/src/services/wishlist.service.ts
@@ -2,10 +2,26 @@ import Wishes from "../sequelize/models/wishes";
 import { Op } from "sequelize";
 import Product from "../sequelize/models/products";
 import User from "../sequelize/models/users";
+import { Role } from "../sequelize/models/roles";
 
-export const getAllUserWishes = async (userId: number) => {
-    const wishes = await Wishes.findAll({ where: { userId }, include: {model: Product, as: 'product'}});
-    return wishes;
+
+export const getAllUserWishes = async (userId: number, roleId: number) => {
+    const role = await Role.findByPk(roleId);
+    if(role?.name === 'seller'){
+        const wishes = await Wishes.findAll({where: { sellerId: userId }, include: [
+            { 
+              model: User,
+              as: 'user',
+              attributes: ['name', 'username', 'email']
+            }
+            ,{ model: Product, as: 'product'}
+          ]});
+        return wishes
+    } else {
+        const wishes = await Wishes.findAll({ where: { userId }, include: {model: Product, as: 'product'}});
+        return wishes;
+    }
+    
 }
 
 export const getSingleWish = async (userId: number, productId: number) => {
@@ -19,9 +35,10 @@ export const getProduct = async (productId: number) => {
 }
 
 export const addToWishlist = async (userId: number, productId:number) => {
-    const addedProduct = await Wishes.create({
-        userId, productId
-    });
+    const product = await getProduct(productId);
+    const sellerId = product?.userId
+    //@ts-ignore
+    const addedProduct = await Wishes.create({ userId, productId, sellerId });
     return addedProduct;
 }
 


### PR DESCRIPTION
#### What does this PR do?

This PR  fixes wishlist functionality

#### Description of Task to be completed?

- fix endpoint naming
- fix login middleware
- sellers should be able to view wishes on their products

#### How should this be manually tested?
1. Clone the repository.
2. Checkout to the branch `fix-wishlist-#187419184`.
3. Run `npm install` to install dependencies.
4. Run `npm run migrate` and `npm run seed`
5. Run `npm run dev` to start the development server.
6. Open a web browser and navigate to the `/docs` endpoint (e.g., `http://localhost:PORT/docs`).
7. Verify that the Swagger UI loads correctly.
8. First authorize by logging in any user and use the token provided (a buyer and a seller for product wishes)
9. Explore the endpoints for wishes and verify that everything is working.

#### What are the relevant pivotal tracker stories?

[Fixes #187419184]