### PR TITLE
Fix-#Login: removed UserInfo field when user logs in

### DIFF
--- a/__test__/cart.test.ts
+++ b/__test__/cart.test.ts
@@ -8,6 +8,8 @@ import User from "../src/sequelize/models/users";
 import bcrypt from "bcrypt";
 import { Role } from "../src/sequelize/models/roles";
 import { dummy } from "./prod";
+import * as userServices from "../src/services/user.service"
+import { number } from "joi";
 
 const queryInterface = sequelize.getQueryInterface();
 
@@ -86,7 +88,8 @@ describe("testing cart", () => {
     // console.log("response 3--->", res3);
 
     sellerToken = res3.body.token;
-    sellerId = res3.body.userInfo?.id;
+    const seller = await userServices.getUserByEmail("seller123@example.com");
+     const sellerId = seller?.id;
 
     await request(app)
       .patch(`/api/v1/users/${sellerId}/role`)

--- a/__test__/payment.test.ts
+++ b/__test__/payment.test.ts
@@ -8,11 +8,12 @@ import User from "../src/sequelize/models/users";
 import bcrypt from "bcryptjs";
 import { Role } from "../src/sequelize/models/roles";
 import { dummy } from "./prod";
+import * as userServive from "../src/services/user.service"
 
 let buyerToken: any;
 let adminToken: any;
 let sellerToken: any;
-let sellerId: number;
+
 
 describe("test stripe api payment", () => {
   beforeAll(async () => {
@@ -79,8 +80,11 @@ describe("test stripe api payment", () => {
       email: "seller123@example.com",
       password: "password",
     });
+
+    const seller = await userServive.getUserByEmail("seller123@example.com");
     sellerToken = sellerResponse.body.token;
-    sellerId = sellerResponse.body.userInfo?.id;
+
+    let sellerId = seller?.id;
 
     await request(app)
       .patch(`/api/v1/users/${sellerId}/role`)

--- a/__test__/product.test.ts
+++ b/__test__/product.test.ts
@@ -15,6 +15,7 @@ import { placeOrder } from "../src/services/payment.service";
 import Cart from "../src/sequelize/models/Cart";
 import CartItem from "../src/sequelize/models/CartItem";
 import OrderItem from "../src/sequelize/models/orderItems";
+import * as userService from "../src/services/user.service"
 
 const userData: any = {
   name: "yvanna",
@@ -137,7 +138,9 @@ describe("Testing product Routes", () => {
         });
         expect(logDummySeller.status).toBe(200);
         token = logDummySeller.body.token;
-        const dummySellerId = logDummySeller.body.userInfo.id;
+
+        const seller = await userService.getUserByEmail(dummySeller.email)
+        const dummySellerId = seller?.id;
     
         const response = await request(app)
           .patch(`/api/v1/users/${dummySellerId}/role`)

--- a/__test__/user.test.ts
+++ b/__test__/user.test.ts
@@ -217,7 +217,8 @@ describe("Testing user Routes", () => {
       password: dummySeller.password,
     });
     expect(logDummySeller.status).toBe(200);
-    const dummySellerId = logDummySeller.body.userInfo.id;
+    const seller = await userServices.getUserByEmail(dummySeller.email);
+    const dummySellerId = seller?.id;
 
     const response = await request(app)
       .patch(`/api/v1/users/${dummySellerId}/role`)

--- a/src/controllers/userControllers.ts
+++ b/src/controllers/userControllers.ts
@@ -83,7 +83,6 @@ export const userLogin = async (req: Request, res: Response) => {
         return res.status(200).json({
           status: 200,
           message: "Logged in",
-          userInfo: userInfo,
           token: accessToken
         });
       }


### PR DESCRIPTION
## what Does this PR DO?
- removes UserInfo field that was part of the response when a user successfully logs in.
## how to test this PR?
- pull the changes on my branch fix-Login
- RUN npm run dev
- try to login.
- you will only the the token of the logged in user.

[fixes #187419169]